### PR TITLE
enlevé doublon dans app.js

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -25,7 +25,6 @@ require("channels")
 // External imports
 import "bootstrap";
 
-import { initScoreBar } from '../components/scorebar';
 
 // Internal imports, e.g:
 // import { initSelect2 } from '../components/init_select2';

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -21,7 +21,6 @@
           </li>
 
           <% if current_user.habitant.house.gift %>
-
             <li class="nav-item">
               <%= link_to "🎁", gift_path(current_user.habitant.house.gift) , class: "nav-link" %>
             </li>


### PR DESCRIPTION
il y avait deux fois : import { initScoreBar } from '../components/scorebar';
dans application.js